### PR TITLE
create notice board entity

### DIFF
--- a/migrations/1700634679995-notice-board.ts
+++ b/migrations/1700634679995-notice-board.ts
@@ -1,0 +1,432 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumnOptions,
+} from 'typeorm';
+const generatePrimaryColumn = (
+  comment: string = '고유 ID',
+): TableColumnOptions => {
+  return {
+    name: 'id',
+    type: 'int',
+    unsigned: true,
+    isPrimary: true,
+    isNullable: false,
+    isGenerated: true,
+    generationStrategy: 'increment',
+    comment,
+  };
+};
+
+const generateCreatedAtColumn = (
+  comment: string = '생성 일자',
+): TableColumnOptions => {
+  return {
+    name: 'created_at',
+    type: 'timestamp',
+    isNullable: false,
+    default: 'CURRENT_TIMESTAMP',
+    comment,
+  };
+};
+
+const generateUpdatedAtColumn = (
+  comment: string = '생성 일자',
+): TableColumnOptions => {
+  return {
+    name: 'updated_at',
+    type: 'timestamp',
+    isNullable: false,
+    default: 'CURRENT_TIMESTAMP',
+    onUpdate: 'CURRENT_TIMESTAMP',
+    comment,
+  };
+};
+export class NoticeBoard1700634679995 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 공지 게시판
+    await queryRunner.createTable(
+      new Table({
+        name: 'notice_board',
+        columns: [
+          generatePrimaryColumn('공지 게시글 고유 ID'),
+          {
+            name: 'user_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '게시글 작성 유저 고유 ID',
+          },
+          {
+            name: 'title',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+            comment: '공지게시글 제목',
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: false,
+            comment: '공지게시글 내용',
+          },
+          {
+            name: 'hit',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            default: 0,
+            comment: '조회수',
+          },
+          {
+            name: 'allow_comment',
+            type: 'tinyint',
+            length: '1',
+            unsigned: true,
+            default: 1,
+            isNullable: false,
+            comment: '댓글 허용 여부 (0: 비활성화, 1: 허용)',
+          },
+          generateCreatedAtColumn(),
+          generateUpdatedAtColumn(),
+        ],
+        foreignKeys: [
+          {
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+    await queryRunner.query('ALTER TABLE notice_board COMMENT = "공지 게시판"');
+
+    // 공지 게시글 반응
+    await queryRunner.createTable(
+      new Table({
+        name: 'notice_board_reaction',
+        columns: [
+          generatePrimaryColumn('공지 게시글 반응 고유 ID'),
+          {
+            name: 'reaction_type_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '반응 타입 고유 ID',
+          },
+          {
+            name: 'user_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '유저 고유 ID',
+          },
+          {
+            name: 'notice_board_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '공지 게시글 고유 ID',
+          },
+          generateCreatedAtColumn(),
+        ],
+        foreignKeys: [
+          {
+            referencedTableName: 'reaction_type',
+            referencedColumnNames: ['id'],
+            columnNames: ['reaction_type_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'notice_board',
+            referencedColumnNames: ['id'],
+            columnNames: ['notice_board_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+    await queryRunner.query(
+      'ALTER TABLE notice_board_reaction COMMENT = "공지 게시글 반응"',
+    );
+
+    // 공지게시글 댓글
+    await queryRunner.createTable(
+      new Table({
+        name: 'notice_board_comment',
+        columns: [
+          generatePrimaryColumn('공지게시글 댓글 고유 ID'),
+          {
+            name: 'user_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '댓글 작성 유저 고유 ID',
+          },
+          {
+            name: 'notice_board_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '게시글 고유 ID',
+          },
+          {
+            name: 'description',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+            comment: '댓글 본문',
+          },
+          {
+            name: 'isAnonymous',
+            type: 'tinyint',
+            length: '1',
+            default: 0,
+            unsigned: true,
+            isNullable: false,
+            comment: '작성자 익명 여부 (0: 실명, 1: 익명)',
+          },
+          generateCreatedAtColumn(),
+          generateUpdatedAtColumn(),
+        ],
+        foreignKeys: [
+          {
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'notice_board',
+            referencedColumnNames: ['id'],
+            columnNames: ['notice_board_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+    await queryRunner.query(
+      'ALTER TABLE notice_board_comment COMMENT = "공지 게시판 댓글"',
+    );
+
+    // 공지 게시글 댓글 반응
+    await queryRunner.createTable(
+      new Table({
+        name: 'notice_board_comment_reaction',
+        columns: [
+          generatePrimaryColumn('공지 게시글 댓글 반응 고유 ID'),
+          {
+            name: 'reaction_type_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '반응 타입 고유 ID',
+          },
+          {
+            name: 'user_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '유저 고유 ID',
+          },
+          {
+            name: 'notice_board_comment_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '공지 게시글 댓글 고유 ID',
+          },
+          generateCreatedAtColumn(),
+        ],
+        foreignKeys: [
+          {
+            referencedTableName: 'reaction_type',
+            referencedColumnNames: ['id'],
+            columnNames: ['reaction_type_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'notice_board_comment',
+            referencedColumnNames: ['id'],
+            columnNames: ['notice_board_comment_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+    await queryRunner.query(
+      'ALTER TABLE notice_board_comment_reaction COMMENT = "공지 게시글 댓글 반응"',
+    );
+
+    // 공지 게시글 대댓글
+    await queryRunner.createTable(
+      new Table({
+        name: 'notice_board_reply_comment',
+        columns: [
+          generatePrimaryColumn('공지 게시글 대댓글 고유 ID'),
+          {
+            name: 'notice_board_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '게시글 고유 ID',
+          },
+          {
+            name: 'notice_board_comment_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '공지 게시글 댓글 고유 ID',
+          },
+          {
+            name: 'user_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '대댓글 작성 유저 고유 ID',
+          },
+          {
+            name: 'description',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+            comment: '대댓글 본문',
+          },
+          {
+            name: 'isAnonymous',
+            type: 'tinyint',
+            length: '1',
+            default: 0,
+            unsigned: true,
+            isNullable: false,
+            comment: '작성자 익명 여부 (0: 실명, 1: 익명)',
+          },
+          generateCreatedAtColumn(),
+          generateUpdatedAtColumn(),
+        ],
+        foreignKeys: [
+          {
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'notice_board',
+            referencedColumnNames: ['id'],
+            columnNames: ['notice_board_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'notice_board_comment',
+            referencedColumnNames: ['id'],
+            columnNames: ['notice_board_comment_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+    await queryRunner.query(
+      'ALTER TABLE notice_board_reply_comment COMMENT = "공지 게시판 대댓글"',
+    );
+
+    // 공지 게시글 대댓글 반응
+    await queryRunner.createTable(
+      new Table({
+        name: 'notice_board_reply_comment_reaction',
+        columns: [
+          generatePrimaryColumn('공지 게시글 대댓글 반응 고유 ID'),
+          {
+            name: 'reaction_type_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '반응 타입 고유 ID',
+          },
+          {
+            name: 'user_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '유저 고유 ID',
+          },
+          {
+            name: 'notice_board_reply_comment_id',
+            type: 'int',
+            unsigned: true,
+            isNullable: false,
+            comment: '공지 게시글 대댓글 고유 ID',
+          },
+          generateCreatedAtColumn(),
+        ],
+        foreignKeys: [
+          {
+            referencedTableName: 'reaction_type',
+            referencedColumnNames: ['id'],
+            columnNames: ['reaction_type_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+          {
+            referencedTableName: 'notice_board_reply_comment',
+            referencedColumnNames: ['id'],
+            columnNames: ['notice_board_reply_comment_id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+    await queryRunner.query(
+      'ALTER TABLE notice_board_reply_comment_reaction COMMENT = "공지 게시글 대댓글 반응"',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable(
+      new Table({ name: 'notice_board_reply_comment_reaction' }),
+    );
+    await queryRunner.dropTable(
+      new Table({ name: 'notice_board_reply_comment' }),
+    );
+    await queryRunner.dropTable(
+      new Table({ name: 'notice_board_comment_reaction' }),
+    );
+    await queryRunner.dropTable(new Table({ name: 'notice_board_comment' }));
+    await queryRunner.dropTable(new Table({ name: 'notice_board_reaction' }));
+    await queryRunner.dropTable(new Table({ name: 'notice_board' }));
+  }
+}

--- a/output/entities/NoticeBoard.ts
+++ b/output/entities/NoticeBoard.ts
@@ -1,0 +1,84 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoticeBoardComment } from './NoticeBoardComment';
+import { NoticeBoardReaction } from './NoticeBoardReaction';
+import { NoticeBoardReplyComment } from './NoticeBoardReplyComment';
+import { User } from './User';
+
+@Entity('notice_board', { schema: 'dongurami_local_db' })
+export class NoticeBoard {
+  @PrimaryGeneratedColumn({
+    type: 'int',
+    name: 'id',
+    comment: '공지 게시글 고유 ID',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column('varchar', { name: 'title', comment: '공지게시글 제목', length: 255 })
+  title: string;
+
+  @Column('text', { name: 'description', comment: '공지게시글 내용' })
+  description: string;
+
+  @Column('int', {
+    name: 'hit',
+    comment: '조회수',
+    unsigned: true,
+    default: () => "'0'",
+  })
+  hit: number;
+
+  @Column('tinyint', {
+    name: 'allow_comment',
+    comment: '댓글 허용 여부 (0: 비활성화, 1: 허용)',
+    unsigned: true,
+    default: () => "'1'",
+  })
+  allowComment: number;
+
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @Column('timestamp', {
+    name: 'updated_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  updatedAt: Date;
+
+  @ManyToOne(() => User, (user) => user.noticeBoards, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+  user: User;
+
+  @OneToMany(
+    () => NoticeBoardComment,
+    (noticeBoardComment) => noticeBoardComment.noticeBoard,
+  )
+  noticeBoardComments: NoticeBoardComment[];
+
+  @OneToMany(
+    () => NoticeBoardReaction,
+    (noticeBoardReaction) => noticeBoardReaction.noticeBoard,
+  )
+  noticeBoardReactions: NoticeBoardReaction[];
+
+  @OneToMany(
+    () => NoticeBoardReplyComment,
+    (noticeBoardReplyComment) => noticeBoardReplyComment.noticeBoard,
+  )
+  noticeBoardReplyComments: NoticeBoardReplyComment[];
+}

--- a/output/entities/NoticeBoardComment.ts
+++ b/output/entities/NoticeBoardComment.ts
@@ -1,0 +1,76 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoticeBoard } from './NoticeBoard';
+import { NoticeBoardCommentReaction } from './NoticeBoardCommentReaction';
+import { NoticeBoardReplyComment } from './NoticeBoardReplyComment';
+import { User } from './User';
+
+@Entity('notice_board_comment', { schema: 'dongurami_local_db' })
+export class NoticeBoardComment {
+  @PrimaryGeneratedColumn({
+    type: 'int',
+    name: 'id',
+    comment: '공지게시글 댓글 고유 ID',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column('varchar', { name: 'description', comment: '댓글 본문', length: 255 })
+  description: string;
+
+  @Column('tinyint', {
+    name: 'isAnonymous',
+    comment: '작성자 익명 여부 (0: 실명, 1: 익명)',
+    unsigned: true,
+    default: () => "'0'",
+  })
+  isAnonymous: number;
+
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @Column('timestamp', {
+    name: 'updated_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  updatedAt: Date;
+
+  @ManyToOne(() => User, (user) => user.noticeBoardComments, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+  user: User;
+
+  @ManyToOne(
+    () => NoticeBoard,
+    (noticeBoard) => noticeBoard.noticeBoardComments,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'notice_board_id', referencedColumnName: 'id' }])
+  noticeBoard: NoticeBoard;
+
+  @OneToMany(
+    () => NoticeBoardCommentReaction,
+    (noticeBoardCommentReaction) =>
+      noticeBoardCommentReaction.noticeBoardComment,
+  )
+  noticeBoardCommentReactions: NoticeBoardCommentReaction[];
+
+  @OneToMany(
+    () => NoticeBoardReplyComment,
+    (noticeBoardReplyComment) => noticeBoardReplyComment.noticeBoardComment,
+  )
+  noticeBoardReplyComments: NoticeBoardReplyComment[];
+}

--- a/output/entities/NoticeBoardCommentReaction.ts
+++ b/output/entities/NoticeBoardCommentReaction.ts
@@ -1,0 +1,51 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoticeBoardComment } from './NoticeBoardComment';
+import { ReactionType } from './ReactionType';
+import { User } from './User';
+
+@Entity('notice_board_comment_reaction', { schema: 'dongurami_local_db' })
+export class NoticeBoardCommentReaction {
+  @PrimaryGeneratedColumn({
+    type: 'int',
+    name: 'id',
+    comment: '공지 게시글 댓글 반응 고유 ID',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @ManyToOne(
+    () => NoticeBoardComment,
+    (noticeBoardComment) => noticeBoardComment.noticeBoardCommentReactions,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'notice_board_comment_id', referencedColumnName: 'id' }])
+  noticeBoardComment: NoticeBoardComment;
+
+  @ManyToOne(() => User, (user) => user.noticeBoardCommentReactions, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+  user: User;
+
+  @ManyToOne(
+    () => ReactionType,
+    (reactionType) => reactionType.noticeBoardCommentReactions,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'reaction_type_id', referencedColumnName: 'id' }])
+  reactionType: ReactionType;
+}

--- a/output/entities/NoticeBoardReaction.ts
+++ b/output/entities/NoticeBoardReaction.ts
@@ -1,0 +1,51 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoticeBoard } from './NoticeBoard';
+import { ReactionType } from './ReactionType';
+import { User } from './User';
+
+@Entity('notice_board_reaction', { schema: 'dongurami_local_db' })
+export class NoticeBoardReaction {
+  @PrimaryGeneratedColumn({
+    type: 'int',
+    name: 'id',
+    comment: '공지 게시글 반응 고유 ID',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @ManyToOne(() => User, (user) => user.noticeBoardReactions, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+  user: User;
+
+  @ManyToOne(
+    () => NoticeBoard,
+    (noticeBoard) => noticeBoard.noticeBoardReactions,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'notice_board_id', referencedColumnName: 'id' }])
+  noticeBoard: NoticeBoard;
+
+  @ManyToOne(
+    () => ReactionType,
+    (reactionType) => reactionType.noticeBoardReactions,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'reaction_type_id', referencedColumnName: 'id' }])
+  reactionType: ReactionType;
+}

--- a/output/entities/NoticeBoardReplyComment.ts
+++ b/output/entities/NoticeBoardReplyComment.ts
@@ -1,0 +1,82 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoticeBoard } from './NoticeBoard';
+import { NoticeBoardComment } from './NoticeBoardComment';
+import { NoticeBoardReplyCommentReaction } from './NoticeBoardReplyCommentReaction';
+import { User } from './User';
+
+@Entity('notice_board_reply_comment', { schema: 'dongurami_local_db' })
+export class NoticeBoardReplyComment {
+  @PrimaryGeneratedColumn({
+    type: 'int',
+    name: 'id',
+    comment: '공지 게시글 대댓글 고유 ID',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column('varchar', {
+    name: 'description',
+    comment: '대댓글 본문',
+    length: 255,
+  })
+  description: string;
+
+  @Column('tinyint', {
+    name: 'isAnonymous',
+    comment: '작성자 익명 여부 (0: 실명, 1: 익명)',
+    unsigned: true,
+    default: () => "'0'",
+  })
+  isAnonymous: number;
+
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @Column('timestamp', {
+    name: 'updated_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  updatedAt: Date;
+
+  @ManyToOne(
+    () => NoticeBoard,
+    (noticeBoard) => noticeBoard.noticeBoardReplyComments,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'notice_board_id', referencedColumnName: 'id' }])
+  noticeBoard: NoticeBoard;
+
+  @ManyToOne(
+    () => NoticeBoardComment,
+    (noticeBoardComment) => noticeBoardComment.noticeBoardReplyComments,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'notice_board_comment_id', referencedColumnName: 'id' }])
+  noticeBoardComment: NoticeBoardComment;
+
+  @ManyToOne(() => User, (user) => user.noticeBoardReplyComments, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+  user: User;
+
+  @OneToMany(
+    () => NoticeBoardReplyCommentReaction,
+    (noticeBoardReplyCommentReaction) =>
+      noticeBoardReplyCommentReaction.noticeBoardReplyComment,
+  )
+  noticeBoardReplyCommentReactions: NoticeBoardReplyCommentReaction[];
+}

--- a/output/entities/NoticeBoardReplyCommentReaction.ts
+++ b/output/entities/NoticeBoardReplyCommentReaction.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoticeBoardReplyComment } from './NoticeBoardReplyComment';
+import { ReactionType } from './ReactionType';
+import { User } from './User';
+
+@Entity('notice_board_reply_comment_reaction', { schema: 'dongurami_local_db' })
+export class NoticeBoardReplyCommentReaction {
+  @PrimaryGeneratedColumn({
+    type: 'int',
+    name: 'id',
+    comment: '공지 게시글 대댓글 반응 고유 ID',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @ManyToOne(
+    () => ReactionType,
+    (reactionType) => reactionType.noticeBoardReplyCommentReactions,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([{ name: 'reaction_type_id', referencedColumnName: 'id' }])
+  reactionType: ReactionType;
+
+  @ManyToOne(
+    () => NoticeBoardReplyComment,
+    (noticeBoardReplyComment) =>
+      noticeBoardReplyComment.noticeBoardReplyCommentReactions,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+  )
+  @JoinColumn([
+    { name: 'notice_board_reply_comment_id', referencedColumnName: 'id' },
+  ])
+  noticeBoardReplyComment: NoticeBoardReplyComment;
+
+  @ManyToOne(() => User, (user) => user.noticeBoardReplyCommentReactions, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])
+  user: User;
+}

--- a/output/entities/ReactionType.ts
+++ b/output/entities/ReactionType.ts
@@ -1,54 +1,76 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
-import { FreeBoardCommentReaction } from "./FreeBoardCommentReaction";
-import { FreeBoardReaction } from "./FreeBoardReaction";
-import { FreeBoardReplyCommentReaction } from "./FreeBoardReplyCommentReaction";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { FreeBoardCommentReaction } from './FreeBoardCommentReaction';
+import { FreeBoardReaction } from './FreeBoardReaction';
+import { FreeBoardReplyCommentReaction } from './FreeBoardReplyCommentReaction';
+import { NoticeBoardCommentReaction } from './NoticeBoardCommentReaction';
+import { NoticeBoardReaction } from './NoticeBoardReaction';
+import { NoticeBoardReplyCommentReaction } from './NoticeBoardReplyCommentReaction';
 
-@Entity("reaction_type", { schema: "dongurami_v2" })
+@Entity('reaction_type', { schema: 'dongurami_v2' })
 export class ReactionType {
   @PrimaryGeneratedColumn({
-    type: "int",
-    name: "id",
-    comment: "반응 타입 고유 ID",
+    type: 'int',
+    name: 'id',
+    comment: '반응 타입 고유 ID',
     unsigned: true,
   })
   id: number;
 
-  @Column("varchar", { name: "name", comment: "반응 타입", length: 30 })
+  @Column('varchar', { name: 'name', comment: '반응 타입', length: 30 })
   name: string;
 
-  @Column("varchar", { name: "memo", comment: "메모", length: 255 })
+  @Column('varchar', { name: 'memo', comment: '메모', length: 255 })
   memo: string;
 
-  @Column("timestamp", {
-    name: "created_at",
-    comment: "생성 일자",
-    default: () => "CURRENT_TIMESTAMP",
+  @Column('timestamp', {
+    name: 'created_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 
-  @Column("timestamp", {
-    name: "updated_at",
-    comment: "생성 일자",
-    default: () => "CURRENT_TIMESTAMP",
+  @Column('timestamp', {
+    name: 'updated_at',
+    comment: '생성 일자',
+    default: () => 'CURRENT_TIMESTAMP',
   })
   updatedAt: Date;
 
   @OneToMany(
     () => FreeBoardCommentReaction,
-    (freeBoardCommentReaction) => freeBoardCommentReaction.reactionType
+    (freeBoardCommentReaction) => freeBoardCommentReaction.reactionType,
   )
   freeBoardCommentReactions: FreeBoardCommentReaction[];
 
   @OneToMany(
     () => FreeBoardReaction,
-    (freeBoardReaction) => freeBoardReaction.reactionType
+    (freeBoardReaction) => freeBoardReaction.reactionType,
   )
   freeBoardReactions: FreeBoardReaction[];
 
   @OneToMany(
     () => FreeBoardReplyCommentReaction,
     (freeBoardReplyCommentReaction) =>
-      freeBoardReplyCommentReaction.reactionType
+      freeBoardReplyCommentReaction.reactionType,
   )
   freeBoardReplyCommentReactions: FreeBoardReplyCommentReaction[];
+
+  @OneToMany(
+    () => NoticeBoardCommentReaction,
+    (noticeBoardCommentReaction) => noticeBoardCommentReaction.reactionType,
+  )
+  noticeBoardCommentReactions: NoticeBoardCommentReaction[];
+
+  @OneToMany(
+    () => NoticeBoardReaction,
+    (noticeBoardReaction) => noticeBoardReaction.reactionType,
+  )
+  noticeBoardReactions: NoticeBoardReaction[];
+
+  @OneToMany(
+    () => NoticeBoardReplyCommentReaction,
+    (noticeBoardReplyCommentReaction) =>
+      noticeBoardReplyCommentReaction.reactionType,
+  )
+  noticeBoardReplyCommentReactions: NoticeBoardReplyCommentReaction[];
 }

--- a/output/entities/User.ts
+++ b/output/entities/User.ts
@@ -16,6 +16,12 @@ import { FreeBoardReplyComment } from './FreeBoardReplyComment';
 import { FreeBoardReplyCommentReaction } from './FreeBoardReplyCommentReaction';
 import { LoginType } from './LoginType';
 import { Major } from './Major';
+import { NoticeBoard } from './NoticeBoard';
+import { NoticeBoardComment } from './NoticeBoardComment';
+import { NoticeBoardCommentReaction } from './NoticeBoardCommentReaction';
+import { NoticeBoardReaction } from './NoticeBoardReaction';
+import { NoticeBoardReplyComment } from './NoticeBoardReplyComment';
+import { NoticeBoardReplyCommentReaction } from './NoticeBoardReplyCommentReaction';
 
 @Entity('user', { schema: 'dongurami_v2' })
 export class User {
@@ -107,11 +113,20 @@ export class User {
   @OneToMany(() => FreeBoard, (freeBoard) => freeBoard.user)
   freeBoards: FreeBoard[];
 
+  @OneToMany(() => NoticeBoard, (noticeBoard) => noticeBoard.user)
+  noticeBoards: NoticeBoard[];
+
   @OneToMany(
     () => FreeBoardComment,
     (freeBoardComment) => freeBoardComment.user,
   )
   freeBoardComments: FreeBoardComment[];
+
+  @OneToMany(
+    () => NoticeBoardComment,
+    (noticeBoardComment) => noticeBoardComment.user,
+  )
+  noticeBoardComments: NoticeBoardComment[];
 
   @OneToMany(
     () => FreeBoardCommentReaction,
@@ -120,10 +135,22 @@ export class User {
   freeBoardCommentReactions: FreeBoardCommentReaction[];
 
   @OneToMany(
+    () => NoticeBoardCommentReaction,
+    (noticeBoardCommentReaction) => noticeBoardCommentReaction.user,
+  )
+  noticeBoardCommentReactions: NoticeBoardCommentReaction[];
+
+  @OneToMany(
     () => FreeBoardReaction,
     (freeBoardReaction) => freeBoardReaction.user,
   )
   freeBoardReactions: FreeBoardReaction[];
+
+  @OneToMany(
+    () => NoticeBoardReaction,
+    (noticeBoardReaction) => noticeBoardReaction.user,
+  )
+  noticeBoardReactions: NoticeBoardReaction[];
 
   @OneToMany(
     () => FreeBoardReplyComment,
@@ -132,10 +159,22 @@ export class User {
   freeBoardReplyComments: FreeBoardReplyComment[];
 
   @OneToMany(
+    () => NoticeBoardReplyComment,
+    (noticeBoardReplyComment) => noticeBoardReplyComment.user,
+  )
+  noticeBoardReplyComments: NoticeBoardReplyComment[];
+
+  @OneToMany(
     () => FreeBoardReplyCommentReaction,
     (freeBoardReplyCommentReaction) => freeBoardReplyCommentReaction.user,
   )
   freeBoardReplyCommentReactions: FreeBoardReplyCommentReaction[];
+
+  @OneToMany(
+    () => NoticeBoardReplyCommentReaction,
+    (noticeBoardReplyCommentReaction) => noticeBoardReplyCommentReaction.user,
+  )
+  noticeBoardReplyCommentReactions: NoticeBoardReplyCommentReaction[];
 
   @ManyToOne(() => Major, (major) => major.users, {
     onDelete: 'CASCADE',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "contributors": [
     "SeokHo Lee <rrgks@naver.com>",
-    "BiGo Jeong <jjb26433@naver.com>"
+    "Biho Jeong <jjb26433@naver.com>"
   ],
   "repository": {
     "type": "github",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "node -r tsconfig-paths/register -r ts-node/register ./node_modules/typeorm/cli.js -d typeorm.config.ts",
     "db:migrate": "npm run typeorm migration:run",
+    "db:migration:create": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:create ./migrations",
     "db:migrate:show": "npm run typeorm migration:show",
     "db:migrate:revert": "npm run typeorm migration:revert"
   },


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
공지 보드의 entity와 migration 파일을 생성 했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
일단 현재 생성되어 있는 자유게시판과 다른 점은 익명에 대한 칼럼이 사라졌고 댓글 허용/비허용에 관한 칼럼이 생성 됐습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#23 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /api/user | 유저 정보 조회 | 추가                   |
