### PR TITLE
delete password regexp pattern at sign in

### DIFF
--- a/src/apis/auth/dto/sign-in-request-body.dto.ts
+++ b/src/apis/auth/dto/sign-in-request-body.dto.ts
@@ -1,8 +1,24 @@
-import { PickType } from '@nestjs/swagger';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { UserLoginType } from '@src/apis/users/constants/user.enum';
 import { CreateUserRequestBodyDto } from '@src/apis/users/dto/create-user-request-body.dto';
+import { IsString, ValidateIf } from 'class-validator';
 
 export class SignInRequestBodyDto extends PickType(CreateUserRequestBodyDto, [
   'loginType',
   'email',
-  'password',
-] as const) {}
+] as const) {
+  @ApiProperty({
+    description: 'password (email 로그인시에만 패턴 검사를 진행합니다.)',
+    type: () => String,
+    nullable: true,
+  })
+  @IsString()
+  @ValidateIf((object, value) => {
+    if (object.loginType === UserLoginType.Email) {
+      return true;
+    }
+
+    return value !== null;
+  })
+  password: string | null;
+}

--- a/src/apis/users/dto/create-user-request-body.dto.ts
+++ b/src/apis/users/dto/create-user-request-body.dto.ts
@@ -62,7 +62,7 @@ export class CreateUserRequestBodyDto
   role: UserRole;
 
   @ApiProperty({
-    description: 'password ',
+    description: 'password (email 로그인시에만 패턴 검사를 진행합니다.)',
     type: () => String,
     nullable: true,
     pattern: String(USER_PASSWORD_REGEXP),


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description

로그인 시 비밀번호 패턴 검사를 제거합닏다

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

패턴 검사를 제거하는 이유는 비밀번호 패턴 정책이 변경될 때 이전 유저는 로그인을하지 못하는 이슈가 생길 수 있기 때문입니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link

#92 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| POST    | /api/auth/sign-in | 로그인 | 추가                   |
