### PR TITLE
operationId Automation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-validator": "^0.14.0",
         "cross-env": "^7.0.3",
         "dotenv": "^16.3.1",
+        "inflection": "^3.0.0",
         "joi": "^17.11.0",
         "mariadb": "^3.2.2",
         "mysql2": "^3.6.3",
@@ -5725,6 +5726,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-3.0.0.tgz",
+      "integrity": "sha512-1zEJU1l19SgJlmwqsEyFTbScw/tkMHFenUo//Y0i+XEP83gDFdMvPizAD/WGcE+l1ku12PcTVHQhO6g5E0UCMw==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/inflight": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "class-validator": "^0.14.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.3.1",
+    "inflection": "^3.0.0",
     "joi": "^17.11.0",
     "mariadb": "^3.2.2",
     "mysql2": "^3.6.3",

--- a/src/apis/auth/contollers/auth.swagger.ts
+++ b/src/apis/auth/contollers/auth.swagger.ts
@@ -21,7 +21,6 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'AuthSignIn',
         ...apiOperationOptions,
       }),
       ApiCreatedResponse({
@@ -59,7 +58,6 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'AuthGetProfile',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -76,7 +74,6 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'AuthGetAccessToken',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),

--- a/src/apis/auth/social/controllers/auth-social.swagger.ts
+++ b/src/apis/auth/social/controllers/auth-social.swagger.ts
@@ -1,15 +1,15 @@
-import { ApiOperator } from "@src/types/type";
-import { AuthSocialController } from "./auth-social.controller";
-import { OperationObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
-import { HttpStatus, applyDecorators } from "@nestjs/common";
-import { ApiCreatedResponse, ApiOperation } from "@nestjs/swagger";
-import { DetailResponseDto } from "@src/interceptors/success-interceptor/dto/detail-response.dto";
-import { UserDto } from "@src/apis/users/dto/user.dto";
-import { ValidationError } from "class-validator";
-import { HttpException } from "@src/http-exceptions/exceptions/http.exception";
-import { COMMON_ERROR_CODE } from "@src/constants/error/common/common-error-code.constant";
-import { USER_ERROR_CODE } from "@src/constants/error/users/user-error-code.constant";
-import { AUTH_ERROR_CODE } from "@src/constants/error/auth/auth-error-code.constant";
+import { ApiOperator } from '@src/types/type';
+import { AuthSocialController } from './auth-social.controller';
+import { OperationObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+import { HttpStatus, applyDecorators } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+import { DetailResponseDto } from '@src/interceptors/success-interceptor/dto/detail-response.dto';
+import { UserDto } from '@src/apis/users/dto/user.dto';
+import { ValidationError } from 'class-validator';
+import { HttpException } from '@src/http-exceptions/exceptions/http.exception';
+import { COMMON_ERROR_CODE } from '@src/constants/error/common/common-error-code.constant';
+import { USER_ERROR_CODE } from '@src/constants/error/users/user-error-code.constant';
+import { AUTH_ERROR_CODE } from '@src/constants/error/auth/auth-error-code.constant';
 
 export const ApiAuthSocial: ApiOperator<keyof AuthSocialController> = {
   CheckRegistration: (
@@ -18,13 +18,12 @@ export const ApiAuthSocial: ApiOperator<keyof AuthSocialController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'CheckRegistration',
         ...apiOperationOptions,
       }),
       ApiCreatedResponse({
-        type: Boolean
+        type: Boolean,
       }),
-    )
+    );
   },
   SignUp: (
     apiOperationOptions: Required<Pick<Partial<OperationObject>, 'summary'>> &
@@ -32,7 +31,6 @@ export const ApiAuthSocial: ApiOperator<keyof AuthSocialController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'Signup',
         ...apiOperationOptions,
       }),
       DetailResponseDto.swaggerBuilder(HttpStatus.CREATED, 'user', UserDto),
@@ -60,7 +58,6 @@ export const ApiAuthSocial: ApiOperator<keyof AuthSocialController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'AuthSignIn',
         ...apiOperationOptions,
       }),
       ApiCreatedResponse({
@@ -91,4 +88,4 @@ export const ApiAuthSocial: ApiOperator<keyof AuthSocialController> = {
       ]),
     );
   },
-}
+};

--- a/src/apis/free-post-comments/controllers/free-post-comments.swagger.ts
+++ b/src/apis/free-post-comments/controllers/free-post-comments.swagger.ts
@@ -25,7 +25,6 @@ export const ApiFreePostComment: ApiOperator<keyof FreePostCommentsController> =
     ): PropertyDecorator => {
       return applyDecorators(
         ApiOperation({
-          operationId: 'FreePostCommentCreate',
           ...apiOperationOptions,
         }),
         ApiBearerAuth(),
@@ -61,7 +60,6 @@ export const ApiFreePostComment: ApiOperator<keyof FreePostCommentsController> =
     ): PropertyDecorator => {
       return applyDecorators(
         ApiOperation({
-          operationId: 'FreePostCommentFindAllAndCount',
           ...apiOperationOptions,
         }),
         PaginationResponseDto.swaggerBuilder(
@@ -93,7 +91,6 @@ export const ApiFreePostComment: ApiOperator<keyof FreePostCommentsController> =
     ): PropertyDecorator => {
       return applyDecorators(
         ApiOperation({
-          operationId: 'FreePostCommentPutUpdate',
           ...apiOperationOptions,
         }),
         ApiBearerAuth(),
@@ -132,7 +129,6 @@ export const ApiFreePostComment: ApiOperator<keyof FreePostCommentsController> =
     ): PropertyDecorator => {
       return applyDecorators(
         ApiOperation({
-          operationId: 'FreePostCommentRemove',
           ...apiOperationOptions,
         }),
         ApiBearerAuth(),
@@ -167,7 +163,6 @@ export const ApiFreePostComment: ApiOperator<keyof FreePostCommentsController> =
     ): PropertyDecorator => {
       return applyDecorators(
         ApiOperation({
-          operationId: 'FreePostCommentCreateReaction',
           ...apiOperationOptions,
         }),
         ApiBearerAuth(),
@@ -202,7 +197,6 @@ export const ApiFreePostComment: ApiOperator<keyof FreePostCommentsController> =
     ): PropertyDecorator => {
       return applyDecorators(
         ApiOperation({
-          operationId: 'FreePostCommentRemoveReaction',
           ...apiOperationOptions,
         }),
         ApiBearerAuth(),

--- a/src/apis/free-post-reply-comments/controllers/free-post-reply-comments.swagger.ts
+++ b/src/apis/free-post-reply-comments/controllers/free-post-reply-comments.swagger.ts
@@ -29,7 +29,6 @@ export const ApiFreePostReplyComment: ApiOperator<
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostReplyCommentCreate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -65,7 +64,6 @@ export const ApiFreePostReplyComment: ApiOperator<
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostReplyCommentFindAllAndCount',
         ...apiOperationOptions,
       }),
       PaginationResponseDto.swaggerBuilder(
@@ -97,7 +95,6 @@ export const ApiFreePostReplyComment: ApiOperator<
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostReplyCommentPutUpdate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -136,7 +133,6 @@ export const ApiFreePostReplyComment: ApiOperator<
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostReplyCommentRemove',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -171,7 +167,6 @@ export const ApiFreePostReplyComment: ApiOperator<
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostReplyCommentCreateReaction',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -206,7 +201,6 @@ export const ApiFreePostReplyComment: ApiOperator<
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostReplyCommentRemoveReaction',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),

--- a/src/apis/free-posts/controllers/free-posts.swagger.ts
+++ b/src/apis/free-posts/controllers/free-posts.swagger.ts
@@ -27,7 +27,7 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostCreate',
+        // operationId: 'FreePostCreate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),

--- a/src/apis/free-posts/controllers/free-posts.swagger.ts
+++ b/src/apis/free-posts/controllers/free-posts.swagger.ts
@@ -27,7 +27,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        // operationId: 'FreePostCreate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -60,7 +59,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostFindAllAndCount',
         ...apiOperationOptions,
       }),
       PaginationResponseDto.swaggerBuilder(
@@ -89,7 +87,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostFindOneOrNotFound',
         ...apiOperationOptions,
       }),
       DetailResponseDto.swaggerBuilder(HttpStatus.OK, 'freePost', FreePostDto),
@@ -114,7 +111,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostPutUpdate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -149,7 +145,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostPatchUpdate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -187,7 +182,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostRemove',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -222,7 +216,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostIncrementHit',
         ...apiOperationOptions,
       }),
       ApiNoContentResponse(),
@@ -247,7 +240,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostCreateReaction',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -282,7 +274,6 @@ export const ApiFreePost: ApiOperator<keyof FreePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FreePostRemoveReaction',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),

--- a/src/apis/major/controllers/major.swagger.ts
+++ b/src/apis/major/controllers/major.swagger.ts
@@ -18,7 +18,6 @@ export const ApiMajors: ApiOperator<keyof MajorController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'CreateNewMajor',
         ...apiOperationOptions,
       }),
       DetailResponseDto.swaggerBuilder(HttpStatus.CREATED, 'major', MajorDto),

--- a/src/apis/major/controllers/major.swagger.ts
+++ b/src/apis/major/controllers/major.swagger.ts
@@ -47,7 +47,6 @@ export const ApiMajors: ApiOperator<keyof MajorController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'GetAllMajors',
         ...apiOperationOptions,
       }),
       CommonResponseDto.swaggerBuilder(HttpStatus.OK, 'majors', MajorDto, {

--- a/src/apis/notice-posts/controllers/notice-posts.swagger.ts
+++ b/src/apis/notice-posts/controllers/notice-posts.swagger.ts
@@ -19,7 +19,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostCreate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -52,7 +51,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostFindAllAndCount',
         ...apiOperationOptions,
       }),
       PaginationResponseDto.swaggerBuilder(
@@ -78,7 +76,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostFindOneOrNotFound',
         ...apiOperationOptions,
       }),
       DetailResponseDto.swaggerBuilder(
@@ -110,7 +107,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostPutUpdate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -148,7 +144,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostPatchUpdate',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -186,7 +181,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostRemove',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),
@@ -221,7 +215,6 @@ export const ApiNoticePost: ApiOperator<keyof NoticePostsController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'NoticePostIncreaseHit',
         ...apiOperationOptions,
       }),
       ApiResponse({ status: HttpStatus.NO_CONTENT }),

--- a/src/apis/root/controllers/root.swagger.ts
+++ b/src/apis/root/controllers/root.swagger.ts
@@ -12,7 +12,6 @@ export const ApiRoot: ApiOperator<keyof RootController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'getFindAllErrorCode',
         ...apiOperationOptions,
       }),
       ApiOkResponse({ type: ErrorCodeResponseDto }),

--- a/src/apis/users/controllers/users.swagger.ts
+++ b/src/apis/users/controllers/users.swagger.ts
@@ -17,7 +17,6 @@ export const ApiUsers: ApiOperator<keyof UsersController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'UsersCreate',
         ...apiOperationOptions,
       }),
       DetailResponseDto.swaggerBuilder(HttpStatus.CREATED, 'user', UserDto),
@@ -46,7 +45,6 @@ export const ApiUsers: ApiOperator<keyof UsersController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'FindOneUserOrNotFound',
         ...apiOperationOptions,
       }),
       DetailResponseDto.swaggerBuilder(HttpStatus.OK, 'user', UserDto),
@@ -70,7 +68,6 @@ export const ApiUsers: ApiOperator<keyof UsersController> = {
   ): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({
-        operationId: 'PutUpdateUser',
         ...apiOperationOptions,
       }),
       ApiBearerAuth(),

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -23,7 +23,7 @@ import { HttpProcessErrorExceptionFilter } from '@src/http-exceptions/filters/ht
 import { HttpRemainderExceptionFilter } from '@src/http-exceptions/filters/http-remainder-exception.filter';
 import { HttpUnauthorizedExceptionFilter } from '@src/http-exceptions/filters/http-unauthorized-exception.filter';
 import { SuccessInterceptor } from '@src/interceptors/success-interceptor/success.interceptor';
-import * as inflection from 'inflection';
+import { singularize } from 'inflection';
 
 @Injectable()
 export class AppService {
@@ -112,26 +112,28 @@ export class AppService {
       .addBearerAuth()
       .build();
 
+    /**
+     * @todo 수정될 수 있음.
+     * ex) controller - Controller 지우고 단수형으로 변경
+     * method name은 그대로
+     * 문제점 - 메서드 네이밍 규칙이 각자 스타일이 달라서 모든 케이스에 대응할 수 없음.
+     * 메서드명, 컨트롤러 명에 같은 단어가 들어있는게 문제가 될 수 있다.
+     * rest 형식으로 가져갔을때 메서드 명을 제어할 수 있는 방법이 있다.
+     * [interface]{@link https://github.com/rrgks6221/nestjs-boiler-plate/blob/main/src/apis/posts/controllers/posts.controller.ts}
+     * [implements controller]{@link https://github.com/rrgks6221/nestjs-boiler-plate/blob/main/src/apis/posts/controllers/posts.controller.ts}
+     */
     const document = SwaggerModule.createDocument(app, config, {
       operationIdFactory: (controllerKey: string, methodKey: string) => {
         const replacedControllerName = controllerKey.replace(/Controller$/, '');
 
-        const singularControllerName = inflection.singularize(
-          replacedControllerName,
+        const singularControllerName = singularize(replacedControllerName);
+
+        const controllerName = singularControllerName.replace(
+          /^(.)*/,
+          (matchStr) => matchStr.toLowerCase(),
         );
 
-        const singularMethodName = inflection.singularize(methodKey);
-
-        const methodName = singularMethodName.replace(
-          singularControllerName,
-          '',
-        );
-
-        const controllerName =
-          singularControllerName.charAt(0).toLowerCase() +
-          singularControllerName.slice(1);
-
-        return `${controllerName}_${methodName}`;
+        return `${controllerName}_${methodKey}`;
       },
     });
 

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -131,11 +131,6 @@ export class AppService {
           singularControllerName.charAt(0).toLowerCase() +
           singularControllerName.slice(1);
 
-        console.log(controllerName);
-
-        console.log(`Original methodKey: ${methodKey}`);
-        console.log(`Replaced methodKey: ${methodName}`);
-
         return `${controllerName}_${methodName}`;
       },
     });

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -124,11 +124,7 @@ export class AppService {
      */
     const document = SwaggerModule.createDocument(app, config, {
       operationIdFactory: (controllerKey: string, methodKey: string) => {
-        const replacedControllerName = controllerKey.replace(/Controller$/, '');
-
-        const singularControllerName = singularize(replacedControllerName);
-
-        const controllerName = singularControllerName.replace(
+        const controllerName = singularize(controllerKey.replace(/Controller$/, '')).replace(
           /^(.)*/,
           (matchStr) => matchStr.toLowerCase(),
         );

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -123,7 +123,7 @@ export class AppService {
         const singularMethodName = inflection.singularize(methodKey);
 
         const methodName = singularMethodName.replace(
-          new RegExp(singularControllerName, 'ig'),
+          singularControllerName,
           '',
         );
 

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -23,6 +23,7 @@ import { HttpProcessErrorExceptionFilter } from '@src/http-exceptions/filters/ht
 import { HttpRemainderExceptionFilter } from '@src/http-exceptions/filters/http-remainder-exception.filter';
 import { HttpUnauthorizedExceptionFilter } from '@src/http-exceptions/filters/http-unauthorized-exception.filter';
 import { SuccessInterceptor } from '@src/interceptors/success-interceptor/success.interceptor';
+import * as inflection from 'inflection';
 
 @Injectable()
 export class AppService {
@@ -113,18 +114,27 @@ export class AppService {
 
     const document = SwaggerModule.createDocument(app, config, {
       operationIdFactory: (controllerKey: string, methodKey: string) => {
-        const replacedController = controllerKey.replace(/Controller$/, '');
+        const replacedControllerName = controllerKey.replace(/Controller$/, '');
 
-        console.log(replacedController);
+        const singularControllerName = inflection.singularize(
+          replacedControllerName,
+        );
 
-        const controllerName =
-          replacedController.charAt(0).toLowerCase() +
-          replacedController.slice(1);
+        const singularMethodName = inflection.singularize(methodKey);
 
-        const methodName = methodKey.replace(
-          new RegExp(`^/${replacedController}/`),
+        const methodName = singularMethodName.replace(
+          new RegExp(singularControllerName, 'ig'),
           '',
         );
+
+        const controllerName =
+          singularControllerName.charAt(0).toLowerCase() +
+          singularControllerName.slice(1);
+
+        console.log(controllerName);
+
+        console.log(`Original methodKey: ${methodKey}`);
+        console.log(`Replaced methodKey: ${methodName}`);
 
         return `${controllerName}_${methodName}`;
       },

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -124,10 +124,9 @@ export class AppService {
      */
     const document = SwaggerModule.createDocument(app, config, {
       operationIdFactory: (controllerKey: string, methodKey: string) => {
-        const controllerName = singularize(controllerKey.replace(/Controller$/, '')).replace(
-          /^(.)*/,
-          (matchStr) => matchStr.toLowerCase(),
-        );
+        const controllerName = singularize(
+          controllerKey.replace(/Controller$/, ''),
+        ).replace(/^(.)*/, (matchStr) => matchStr.toLowerCase());
 
         return `${controllerName}_${methodKey}`;
       },

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -111,7 +111,24 @@ export class AppService {
       .addBearerAuth()
       .build();
 
-    const document = SwaggerModule.createDocument(app, config, {});
+    const document = SwaggerModule.createDocument(app, config, {
+      operationIdFactory: (controllerKey: string, methodKey: string) => {
+        const replacedController = controllerKey.replace(/Controller$/, '');
+
+        console.log(replacedController);
+
+        const controllerName =
+          replacedController.charAt(0).toLowerCase() +
+          replacedController.slice(1);
+
+        const methodName = methodKey.replace(
+          new RegExp(`^/${replacedController}/`),
+          '',
+        );
+
+        return `${controllerName}_${methodName}`;
+      },
+    });
 
     SwaggerModule.setup('api-docs', app, document, {
       jsonDocumentUrl: JSON_PATH,


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
operationId를 자동화 했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
먼저 Controller 클래스들의 이름에서 Controller를 replace 메서드를 통해 지웁니다.
그 Controller들의 이름과 메서드의 이름을 단수형으로 변경합니다.
메서드의 이름에서 단수형으로 바뀐 컨트롤러의 이름들이 들어간 문자를 지웁니다.
컨트롤러 이름에서 첫글자를 소문자로 변경합니다.
`${controllerName}_${methodName}`의 컨벤션으로 return 합니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
[QYOG-55](https://dongurami.atlassian.net/browse/QYOG-55)

<!-- 작업한 API (선택) -->
### API


[QYOG-55]: https://dongurami.atlassian.net/browse/QYOG-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ