### PR TITLE
TypeORM timezone 설정 추가

### DIFF
--- a/src/core/type-orm/type-orm-module-options.factory.ts
+++ b/src/core/type-orm/type-orm-module-options.factory.ts
@@ -17,6 +17,7 @@ export class TypeOrmModuleOptionsFactory implements TypeOrmOptionsFactory {
       database: this.appConfigService.get<string>(ENV_KEY.RDB_DATABASE),
       entities: ['dist/**/entities/*{.ts,.js}'],
       logging: true,
+      timezone: 'UTC',
     };
   }
 }

--- a/src/core/type-orm/type-orm-module-options.factory.ts
+++ b/src/core/type-orm/type-orm-module-options.factory.ts
@@ -17,7 +17,7 @@ export class TypeOrmModuleOptionsFactory implements TypeOrmOptionsFactory {
       database: this.appConfigService.get<string>(ENV_KEY.RDB_DATABASE),
       entities: ['dist/**/entities/*{.ts,.js}'],
       logging: true,
-      timezone: 'UTC',
+      timezone: '+00:00',
     };
   }
 }

--- a/typeorm.config.ts
+++ b/typeorm.config.ts
@@ -16,5 +16,5 @@ export default new DataSource({
   entities: ['./src/entities/*.ts'],
   migrationsTableName: 'migrations', // migration 이력을 저장하는 테이블
   migrations: ['migrations/**/[0-9]*.ts'], // migration 할 파일들이 있는 directory
-  timezone: 'UTC',
+  timezone: '+00:00',
 });

--- a/typeorm.config.ts
+++ b/typeorm.config.ts
@@ -16,4 +16,5 @@ export default new DataSource({
   entities: ['./src/entities/*.ts'],
   migrationsTableName: 'migrations', // migration 이력을 저장하는 테이블
   migrations: ['migrations/**/[0-9]*.ts'], // migration 할 파일들이 있는 directory
+  timezone: 'UTC',
 });


### PR DESCRIPTION
<!-- 지라 티켓 url -->
### JIRA
[QYOG-80](https://dongurami.atlassian.net/jira/software/projects/QYOG/issues/QYOG-80)

<!-- 내용 (필수) -->
### Description
정확한 원인은 잘 모르겠는데 mysql db의 created_at 칼럼에서는 db의 timezone에 맞춰서 정상적으로 시간이 저장되는데 실제로 애플리케이션 환경에서 쿼리문을 통해 값을 뽑아오면 값이 자동으로 KST --> UTC시간으로 자동으로 변환됩니다. 
mysql에서 timezone을 변경하면 timestamp 컬럼들의 값들이 timezone의 시간에 맞게 자동으로 변환되는걸 확인했고 이 때문이라고 라고 생각을 했는데 PostgresSQL을 사용하는 다른 사람도 해당 문제를 같이 겪고 있었고 PostgresSQL에서는 timezone을 변경해도 timestamp 컬럼들의 값이 자동으로 변환되지 않는 것으로 보아 
node.js, db의 timezone은 내부적으로 UTC로 설정되어 있음 --> 서버의 내부적인 timezone값이 Asia/Seoul로 설정되어 있음. --> 값을 불러올 때 자동으로 driver 혹은 node.js가 UTC에 맞추려고 -9 한다??
정도로 예상합니다.


<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
typeorm config에서 timezone 설정해주면 정상작동 합니다.
timezone에 UTC라는 값을 줬었는데
Ignoring invalid timezone passed to Connection: UTC. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
작동은 잘하는데 해당 경고문구가 발생해서 +00:00으로 변경하겠습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
https://github.com/knex/knex/issues/4593

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link

1. [QYOG-80:timezone설정](https://dongurami.atlassian.net/jira/software/projects/QYOG/issues/QYOG-80)

<!-- 작업한 API (선택) -->
### API


[QYOG-80]: https://dongurami.atlassian.net/browse/QYOG-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ