### PR TITLE
operationId 컨트롤러 명이 전부 소문자로 나오는 문제 수정

### DIFF
--- a/src/bootstrap.service.ts
+++ b/src/bootstrap.service.ts
@@ -128,7 +128,7 @@ export class BootstrapService {
       operationIdFactory: (controllerKey: string, methodKey: string) => {
         const controllerName = singularize(
           controllerKey.replace(/Controller$/, ''),
-        ).replace(/^(.)*/, (matchStr) => matchStr.toLowerCase());
+        ).replace(/^(.)/, (matchStr) => matchStr.toLowerCase());
 
         return `${controllerName}_${methodKey}`;
       },


### PR DESCRIPTION
<!-- 지라 티켓 url -->
### JIRA
[QYOG-84](https://dongurami.atlassian.net/browse/QYOG-84)

<!-- 내용 (필수) -->
### Description
정규식이 컨트롤러 이름을 모두 소문자로 바꿔버려서 첫글자만 바꾸도록 수정했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link

<!-- 작업한 API (선택) -->
### API


[QYOG-84]: https://dongurami.atlassian.net/browse/QYOG-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ